### PR TITLE
Compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,16 @@ include_directories(${Vulkan_INCLUDE_DIR})
 add_executable(mandelbrot src/mandelbrot.cc src/lodepng.cpp src/vulkan_ext.c)
 
 target_link_libraries(mandelbrot ${Vulkan_LIBRARY})
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/shaders)
+
+add_custom_target(shader
+	ALL
+	DEPENDS shaders/comp.spv
+)
+
+add_custom_command(
+	OUTPUT shaders/comp.spv
+	COMMAND glslc ${CMAKE_SOURCE_DIR}/shaders/shader.comp -o shaders/comp.spv
+	MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/shaders/shader.comp
+)

--- a/src/mandelbrot.cc
+++ b/src/mandelbrot.cc
@@ -82,7 +82,7 @@ class MandelbrotApp {
     for (const auto &layer_property : layer_props) {
       std::cerr << "  " << layer_property.layerName << "\t\t"
                 << layer_property.description << std::endl;
-      if (std::string(layer_property.layerName) == kValidationLayer) {
+      if (std::string{kValidationLayer} == layer_property.layerName) {
         enabled_layers_.push_back(kValidationLayer);
       }
     }
@@ -95,7 +95,7 @@ class MandelbrotApp {
               << std::endl;
     for (const auto &extension_prop : extension_props) {
       std::cerr << "  " << extension_prop.extensionName << std::endl;
-      if (std::string(extension_prop.extensionName) == kDebugReportExtension) {
+      if (std::string{kDebugReportExtension} == extension_prop.extensionName) {
         enabled_extensions_.push_back(kDebugReportExtension);
       }
     }
@@ -264,7 +264,8 @@ class MandelbrotApp {
     auto pipeline_create_info = vk::ComputePipelineCreateInfo();
     pipeline_create_info.setStage(shader_stage_create_info)
         .setLayout(*pipeline_layout_);
-    pipeline_ = device_->createComputePipelineUnique({}, pipeline_create_info);
+    pipeline_ =
+	device_->createComputePipelineUnique({}, pipeline_create_info).value;
   }
 
   void CreateCommandPool() {


### PR DESCRIPTION
Fix build issues on Fedora 41.

Conversion of `const vk::ArrayWrapper1D<char, 256>&` to `std::string` is ambiguous. Convert the other side to `std::string` instead.

The result of `createComputePipelineUnique` needs to be "unwrapped" manually. Implicit unwrapping is no longer supported.

There was no rule to compile the shader. Someone experimenting with the shader source would need to compile it manually to see the result of the change.

The pre-compiled shader was in the source directory, but the `mandelbrot` binary would look in the binary directory. That would break when building outside the source tree. The shader is generated in the binary tree now.